### PR TITLE
Added a check of to avoid using uninitialized NoBestMatchFullRefHaps

### DIFF
--- a/src/MarkovModel.cpp
+++ b/src/MarkovModel.cpp
@@ -701,7 +701,7 @@ void MarkovModel::FoldBackProbabilitiesWithThreshold(ReducedHaplotypeInfo &Info)
     noNewReducedStates = 0;
     int UnMappedIndex, MappedIndex;
 
-    for (int index=0; index<NoBestMatchFullRefHaps; index++)
+    for (int index=0; MyAllVariables->myModelVariables.probThreshold>0.0 && index<NoBestMatchFullRefHaps; index++)
     {
         UnMappedIndex=BestMatchFullRefHaps[index];
         MappedIndex=Info.uniqueIndexMap[UnMappedIndex];


### PR DESCRIPTION
I believe loop should never run if MyAllVariables->myModelVariables.probThreshold=0.0, but since `NoBestMatchFullRefHaps` remains uninitialized it can and that leads to a `Segmentation fault`.

I think this closes #17.