### PR TITLE
Changed how probThreshold==0 is handled to get dosage values

### DIFF
--- a/src/MarkovModel.cpp
+++ b/src/MarkovModel.cpp
@@ -384,14 +384,11 @@ void MarkovModel::ImputeChunk(int group, int &hapID, int &position,
 
         MidPoint = (UnfoldTheseSites[StartPoint] + UnfoldTheseSites[EndPoint])/2 - startIndex ;
 
-        if(MyAllVariables->myModelVariables.probThreshold>0.0)
-        {
-            unfoldProbabilitiesWithThreshold(group, ThisBlockLeftNoRecoProb[MidPoint],
-                                             ThisLeftprob[MidPoint],
-                                             ThisBlockRightNoRecoProb[MidPoint],
-                                             ThisBlockRightProb[MidPoint],
-                                             leftEndProb, rightEndProb);
-        }
+        unfoldProbabilitiesWithThreshold(group, ThisBlockLeftNoRecoProb[MidPoint],
+                                         ThisLeftprob[MidPoint],
+                                         ThisBlockRightNoRecoProb[MidPoint],
+                                         ThisBlockRightProb[MidPoint],
+                                         leftEndProb, rightEndProb);
 
         for(int i=EndPoint;i>=StartPoint;i--)
         {
@@ -605,7 +602,7 @@ void MarkovModel::unfoldProbabilitiesWithThreshold(int bridgeIndex,
     double tempInvSum = SumOfProb[MidPoint];
     double maxVal = 0.0, sum = 0.0;
 
-    if(!MyAllVariables->myOutFormat.verbose && MyAllVariables->myModelVariables.probThreshold>0.0)
+    if(!MyAllVariables->myOutFormat.verbose)
     {
         int Index=0;
         NoBestMatchHaps=0;
@@ -627,7 +624,7 @@ void MarkovModel::unfoldProbabilitiesWithThreshold(int bridgeIndex,
         }
     }
 
-    if(MyAllVariables->myOutFormat.verbose && MyAllVariables->myModelVariables.probThreshold>0.0)
+    if(MyAllVariables->myOutFormat.verbose)
     {
         int Index=0;
         NoBestMatchHaps=0;
@@ -701,7 +698,7 @@ void MarkovModel::FoldBackProbabilitiesWithThreshold(ReducedHaplotypeInfo &Info)
     noNewReducedStates = 0;
     int UnMappedIndex, MappedIndex;
 
-    for (int index=0; MyAllVariables->myModelVariables.probThreshold>0.0 && index<NoBestMatchFullRefHaps; index++)
+    for (int index=0; index<NoBestMatchFullRefHaps; index++)
     {
         UnMappedIndex=BestMatchFullRefHaps[index];
         MappedIndex=Info.uniqueIndexMap[UnMappedIndex];
@@ -905,22 +902,8 @@ void MarkovModel::initializeMatrices()
 
     FinalBestMatchfHaps.resize(rHapFull->maxRepSize);
     FinalBestMatchfHapsIndicator.resize(rHapFull->maxRepSize);
-    if(MyAllVariables->myModelVariables.probThreshold>0.0)
-    {
-        BestMatchHaps.resize(rHap->maxRepSize);
-        BestMatchFullRefHaps.resize(refCount);
-    }
-    else
-    {
-        for(int i=0;i<rHapFull->maxRepSize ;i++)
-        {
-            FinalBestMatchfHaps[i]=i;
-        }
-    }
-
-
-
-
+    BestMatchHaps.resize(rHap->maxRepSize);
+    BestMatchFullRefHaps.resize(refCount);
 }
 
 


### PR DESCRIPTION
Submitting another pull request to address #17 since I believe my previous pull request handled the segfault, but didn't properly handle computing the dosages due to not computing `probHapFullAverage` (since `unfoldProbabilitiesWithThreshold()` was skipped) which is used by `FoldBackProbabilitiesWithThreshold()` to compute `FoldedProbValue` for all the "best haps". This is necessary since `CreatePRefPAlt()` uses this to compute the dosage. 

I removed those skips with minimal changes (always use BestMatchHaps) and if `probThreshold == 0` then automatically assign all haplotypes in reference to `BestMatchHaps` and let the remaining logic handle it. Its probably only slightly more computationally expensive.

I think a similar issue exists with the `--minimac3` flag since I am not getting proper dosages there as well.