### PR TITLE
Download zlib via https and verify checksum

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-zlib,http://zlib.net/zlib-1.2.11.tar.gz
+zlib,https://zlib.net/zlib-1.2.11.tar.gz --hash md5:1c9f62f0778697a09d36121ead88e08e
 statgen/libStatGen --cmake dep/libstatgen.cmake


### PR DESCRIPTION
This (small) pull request changes the downloading of `zlib-1.2.11.tar.gz` to use https instead of http and verify the md5 checksum of the file, increasing the security.